### PR TITLE
fix(academy): cross-locale slug-mismatch redirect

### DIFF
--- a/src/app/[locale]/academy/[category]/[slug]/page.tsx
+++ b/src/app/[locale]/academy/[category]/[slug]/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next'
-import { notFound } from 'next/navigation'
+import { notFound, permanentRedirect } from 'next/navigation'
 import Script from 'next/script'
 import { getTranslations, setRequestLocale } from 'next-intl/server'
 import { AuthorByline } from '@/components/shared/author-byline'
@@ -73,6 +73,16 @@ export default async function AcademyArticlePage({ params }: PageProps) {
 
   const post = await getAcademyPostBySlug(slug, locale)
   if (!post) notFound()
+
+  if (post.section === 'newsroom') {
+    permanentRedirect(`/${locale}/newsroom/${post.slug}`)
+  }
+  if (post.category && post.category !== category) {
+    permanentRedirect(`/${locale}/academy/${post.category}/${post.slug}`)
+  }
+  if (post.slug !== slug) {
+    permanentRedirect(`/${locale}/academy/${category}/${post.slug}`)
+  }
 
   const [author, relatedPosts, tCategories, tAcademy, tCommon] = await Promise.all([
     post.authorId ? getAuthorBySlug(post.authorId) : Promise.resolve(null),


### PR DESCRIPTION
## Summary

Add cross-locale slug-mismatch redirect to the academy article page, mirroring the newsroom article page's existing pattern. Without this, hitting `/es/academy/<cat>/<en-slug>` for a translated post serves Spanish content under an English-slug URL — duplicate content under multiple URLs (caught during the Phase B.3 e2e smoke test).

The backend already returns the canonical locale slug via its cross-locale fallback in `PostService.getBySlug`; this PR just plumbs the redirect through the academy article page. Also handles section/category drift.

## Test plan

- [x] `npm run check-all` passes (115 tests, typecheck + lint + format clean)
- [ ] Smoke test: `/es/academy/security/<en-slug>` → 301 → `/es/academy/security/<es-slug>` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)