### PR TITLE
feat: Core Web Vitals + content-aware GA4 + CTA instrumentation

### DIFF
--- a/__tests__/components/analytics/page-context.test.tsx
+++ b/__tests__/components/analytics/page-context.test.tsx
@@ -1,0 +1,31 @@
+import { render } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+describe('PageContext', () => {
+  beforeEach(() => {
+    Object.defineProperty(globalThis, 'window', { value: {}, configurable: true, writable: true })
+  })
+
+  it('calls setContentContext with passed props', async () => {
+    const gtag = vi.fn()
+    ;(window as unknown as { gtag: typeof gtag }).gtag = gtag
+    ;(window as unknown as { hasAnalyticsConsent: () => boolean }).hasAnalyticsConsent = () => true
+    const { PageContext } = await import('../../../src/components/analytics/page-context')
+    render(<PageContext section='academy' slug='intro' locale='en' />)
+    expect(gtag).toHaveBeenCalledWith(
+      'set',
+      expect.objectContaining({
+        content_group: 'academy',
+        post_section: 'academy',
+        post_slug: 'intro',
+        post_locale: 'en',
+      })
+    )
+  })
+
+  it('renders null (no visible output)', async () => {
+    const { PageContext } = await import('../../../src/components/analytics/page-context')
+    const { container } = render(<PageContext section='newsroom' slug='x' locale='en' />)
+    expect(container.firstChild).toBeNull()
+  })
+})

--- a/__tests__/components/analytics/track.test.tsx
+++ b/__tests__/components/analytics/track.test.tsx
@@ -1,52 +1,52 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 describe('track wrappers', () => {
   beforeEach(() => {
-    Object.defineProperty(globalThis, 'window', { value: {}, configurable: true, writable: true });
-    const gtag = vi.fn();
-    (window as unknown as { gtag: typeof gtag }).gtag = gtag;
-    (window as unknown as { hasAnalyticsConsent: () => boolean }).hasAnalyticsConsent = () => true;
-  });
+    Object.defineProperty(globalThis, 'window', { value: {}, configurable: true, writable: true })
+    const gtag = vi.fn()
+    ;(window as unknown as { gtag: typeof gtag }).gtag = gtag
+    ;(window as unknown as { hasAnalyticsConsent: () => boolean }).hasAnalyticsConsent = () => true
+  })
 
   it('TrackCtaButton emits cta_click on click', async () => {
-    const { TrackCtaButton } = await import('../../../src/components/analytics/track');
-    const handler = vi.fn();
+    const { TrackCtaButton } = await import('../../../src/components/analytics/track')
+    const handler = vi.fn()
     const { getByRole } = render(
-      <TrackCtaButton ctaId="enterprise_contact" onClick={handler}>Talk to us</TrackCtaButton>,
-    );
-    fireEvent.click(getByRole('button'));
-    expect(handler).toHaveBeenCalled();
-    const calls = (window.gtag as unknown as ReturnType<typeof vi.fn>).mock.calls;
-    expect(calls[0]).toEqual(['event', 'cta_click', { cta_id: 'enterprise_contact' }]);
-  });
+      <TrackCtaButton ctaId='enterprise_contact' onClick={handler}>
+        Talk to us
+      </TrackCtaButton>
+    )
+    fireEvent.click(getByRole('button'))
+    expect(handler).toHaveBeenCalled()
+    const calls = (window.gtag as unknown as ReturnType<typeof vi.fn>).mock.calls
+    expect(calls[0]).toEqual(['event', 'cta_click', { cta_id: 'enterprise_contact' }])
+  })
 
   it('TrackOutboundLink emits outbound_click with target host', async () => {
-    const { TrackOutboundLink } = await import('../../../src/components/analytics/track');
+    const { TrackOutboundLink } = await import('../../../src/components/analytics/track')
     const { getByRole } = render(
-      <TrackOutboundLink href="https://example.com/foo">Example</TrackOutboundLink>,
-    );
-    fireEvent.click(getByRole('link'));
-    const calls = (window.gtag as unknown as ReturnType<typeof vi.fn>).mock.calls;
+      <TrackOutboundLink href='https://example.com/foo'>Example</TrackOutboundLink>
+    )
+    fireEvent.click(getByRole('link'))
+    const calls = (window.gtag as unknown as ReturnType<typeof vi.fn>).mock.calls
     expect(calls[0]).toEqual([
       'event',
       'outbound_click',
       { target_host: 'example.com', target_url: 'https://example.com/foo' },
-    ]);
-  });
+    ])
+  })
 
   it('TrackVideoPlay emits video_play on play event', async () => {
-    const { TrackVideoPlay } = await import('../../../src/components/analytics/track');
+    const { TrackVideoPlay } = await import('../../../src/components/analytics/track')
     const { container } = render(
-      <TrackVideoPlay videoId="hero-loop" placement="home">
-        <video data-testid="v" />
-      </TrackVideoPlay>,
-    );
-    const video = container.querySelector('video')!;
-    fireEvent.play(video);
-    const calls = (window.gtag as unknown as ReturnType<typeof vi.fn>).mock.calls;
-    expect(calls[0]).toEqual([
-      'event', 'video_play', { video_id: 'hero-loop', placement: 'home' },
-    ]);
-  });
-});
+      <TrackVideoPlay videoId='hero-loop' placement='home'>
+        <video data-testid='v' />
+      </TrackVideoPlay>
+    )
+    const video = container.querySelector('video')!
+    fireEvent.play(video)
+    const calls = (window.gtag as unknown as ReturnType<typeof vi.fn>).mock.calls
+    expect(calls[0]).toEqual(['event', 'video_play', { video_id: 'hero-loop', placement: 'home' }])
+  })
+})

--- a/__tests__/components/analytics/track.test.tsx
+++ b/__tests__/components/analytics/track.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+
+describe('track wrappers', () => {
+  beforeEach(() => {
+    Object.defineProperty(globalThis, 'window', { value: {}, configurable: true, writable: true });
+    const gtag = vi.fn();
+    (window as unknown as { gtag: typeof gtag }).gtag = gtag;
+    (window as unknown as { hasAnalyticsConsent: () => boolean }).hasAnalyticsConsent = () => true;
+  });
+
+  it('TrackCtaButton emits cta_click on click', async () => {
+    const { TrackCtaButton } = await import('../../../src/components/analytics/track');
+    const handler = vi.fn();
+    const { getByRole } = render(
+      <TrackCtaButton ctaId="enterprise_contact" onClick={handler}>Talk to us</TrackCtaButton>,
+    );
+    fireEvent.click(getByRole('button'));
+    expect(handler).toHaveBeenCalled();
+    const calls = (window.gtag as unknown as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls[0]).toEqual(['event', 'cta_click', { cta_id: 'enterprise_contact' }]);
+  });
+
+  it('TrackOutboundLink emits outbound_click with target host', async () => {
+    const { TrackOutboundLink } = await import('../../../src/components/analytics/track');
+    const { getByRole } = render(
+      <TrackOutboundLink href="https://example.com/foo">Example</TrackOutboundLink>,
+    );
+    fireEvent.click(getByRole('link'));
+    const calls = (window.gtag as unknown as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls[0]).toEqual([
+      'event',
+      'outbound_click',
+      { target_host: 'example.com', target_url: 'https://example.com/foo' },
+    ]);
+  });
+
+  it('TrackVideoPlay emits video_play on play event', async () => {
+    const { TrackVideoPlay } = await import('../../../src/components/analytics/track');
+    const { container } = render(
+      <TrackVideoPlay videoId="hero-loop" placement="home">
+        <video data-testid="v" />
+      </TrackVideoPlay>,
+    );
+    const video = container.querySelector('video')!;
+    fireEvent.play(video);
+    const calls = (window.gtag as unknown as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls[0]).toEqual([
+      'event', 'video_play', { video_id: 'hero-loop', placement: 'home' },
+    ]);
+  });
+});

--- a/__tests__/components/analytics/web-vitals-reporter.test.tsx
+++ b/__tests__/components/analytics/web-vitals-reporter.test.tsx
@@ -1,0 +1,56 @@
+import { render } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const onLCPMock = vi.fn()
+const onINPMock = vi.fn()
+const onCLSMock = vi.fn()
+
+vi.mock('web-vitals/attribution', () => ({
+  onLCP: onLCPMock,
+  onINP: onINPMock,
+  onCLS: onCLSMock,
+}))
+
+describe('WebVitalsReporter', () => {
+  beforeEach(() => {
+    onLCPMock.mockReset()
+    onINPMock.mockReset()
+    onCLSMock.mockReset()
+    Object.defineProperty(globalThis, 'window', { value: {}, configurable: true, writable: true })
+  })
+
+  it('registers callbacks for LCP, INP, CLS', async () => {
+    const { WebVitalsReporter } =
+      await import('../../../src/components/analytics/web-vitals-reporter')
+    render(<WebVitalsReporter />)
+    expect(onLCPMock).toHaveBeenCalledTimes(1)
+    expect(onINPMock).toHaveBeenCalledTimes(1)
+    expect(onCLSMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('callback forwards metric to gtag when consent is granted', async () => {
+    const gtag = vi.fn()
+    ;(window as unknown as { gtag: typeof gtag }).gtag = gtag
+    ;(window as unknown as { hasAnalyticsConsent: () => boolean }).hasAnalyticsConsent = () => true
+
+    const { WebVitalsReporter } =
+      await import('../../../src/components/analytics/web-vitals-reporter')
+    render(<WebVitalsReporter />)
+    const cb = onLCPMock.mock.calls[0][0]
+    cb({
+      name: 'LCP',
+      value: 2300,
+      delta: 100,
+      id: 'v3-1',
+      rating: 'needs-improvement',
+      attribution: { element: '#hero img' },
+    })
+    expect(gtag).toHaveBeenCalled()
+    const [event, name, params] = gtag.mock.calls[0]
+    expect(event).toBe('event')
+    expect(name).toBe('LCP')
+    expect(params.metric_id).toBe('v3-1')
+    expect(params.metric_rating).toBe('needs-improvement')
+    expect(params.debug_target).toBe('#hero img')
+  })
+})

--- a/__tests__/lib/gtag.test.ts
+++ b/__tests__/lib/gtag.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+describe('lib/gtag', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    delete (globalThis as { window?: unknown }).window
+    Object.defineProperty(globalThis, 'window', { value: {}, configurable: true, writable: true })
+  })
+
+  it('trackEvent no-ops when gtag is undefined', async () => {
+    const { trackEvent } = await import('../../src/lib/gtag')
+    expect(() => trackEvent('foo', { bar: 1 })).not.toThrow()
+  })
+
+  it('trackEvent no-ops when consent helper returns false', async () => {
+    const gtag = vi.fn()
+    ;(window as unknown as { gtag: typeof gtag }).gtag = gtag
+    ;(window as unknown as { hasAnalyticsConsent: () => boolean }).hasAnalyticsConsent = () => false
+    const { trackEvent } = await import('../../src/lib/gtag')
+    trackEvent('foo', { bar: 1 })
+    expect(gtag).not.toHaveBeenCalled()
+  })
+
+  it('trackEvent calls gtag when consent is granted', async () => {
+    const gtag = vi.fn()
+    ;(window as unknown as { gtag: typeof gtag }).gtag = gtag
+    ;(window as unknown as { hasAnalyticsConsent: () => boolean }).hasAnalyticsConsent = () => true
+    const { trackEvent } = await import('../../src/lib/gtag')
+    trackEvent('download_click', { platform: 'ios' })
+    expect(gtag).toHaveBeenCalledWith('event', 'download_click', { platform: 'ios' })
+  })
+
+  it('setContentContext calls gtag set with content params', async () => {
+    const gtag = vi.fn()
+    ;(window as unknown as { gtag: typeof gtag }).gtag = gtag
+    ;(window as unknown as { hasAnalyticsConsent: () => boolean }).hasAnalyticsConsent = () => true
+    const { setContentContext } = await import('../../src/lib/gtag')
+    setContentContext({ section: 'academy', slug: 'intro', locale: 'en' })
+    expect(gtag).toHaveBeenCalledWith('set', {
+      content_group: 'academy',
+      post_section: 'academy',
+      post_slug: 'intro',
+      post_locale: 'en',
+    })
+  })
+})

--- a/docs/analytics-setup.md
+++ b/docs/analytics-setup.md
@@ -1,0 +1,76 @@
+# Web Analytics — Setup
+
+ssp-website reports to Google Analytics 4 via `gtag.js`, gated by user consent
+through the cookie banner.
+
+## Required environment variables
+
+```sh
+NEXT_PUBLIC_GA_ID=G-XXXXXXXXXX
+```
+
+That's the only var required client-side. If unset, all tracking no-ops.
+
+## What we report
+
+- **Standard pageviews** — automatic via `gtag.js`.
+- **Core Web Vitals** — `LCP`, `INP`, `CLS` as GA4 events with
+  `metric_id`, `metric_value`, `metric_delta`, `metric_rating`,
+  `debug_target` event params. See `src/components/analytics/web-vitals-reporter.tsx`.
+- **Content context** — on academy/newsroom pages we attach
+  `content_group`, `post_section`, `post_slug`, `post_locale` so reports
+  can be filtered by section and language. See
+  `src/components/analytics/page-context.tsx`.
+- **CTAs** — `cta_click` / `form_submit` events fire on the highest-value
+  CTAs: header Download buttons, download-page cards (Chrome/Firefox/Edge/Brave
+  extensions, mobile section, Play Store, App Store), Enterprise launch
+  buttons (hero / contact section / footer), and the contact form on
+  successful submission.
+
+### `cta_id` reference
+
+| cta_id | Where | Notes |
+|---|---|---|
+| `download_header` | Top nav, desktop | |
+| `download_header_mobile` | Top nav, mobile | |
+| `download_option` | Download page extension/section cards | `platform` = the option's id (e.g. `chrome`, `firefox`, `mobile`). Note: `platform: 'mobile'` is a click on the "scroll to mobile section" card, not an actual install. |
+| `download_mobile` | Download page Play Store / App Store anchors | `platform: 'android' \| 'ios'`. These are real install-intent taps. |
+| `enterprise_launch_app` | Enterprise hero CTA | |
+| `enterprise_launch_app_contact` | Enterprise contact section | |
+| `enterprise_launch_app_footer` | Enterprise final CTA | |
+
+## GA4 admin steps (one-time)
+
+In GA4 admin → Custom definitions → register **event-scoped** custom dimensions
+for these parameter names. GA4 only surfaces custom params in reports once
+they're registered:
+
+- `content_group`, `post_section`, `post_slug`, `post_locale`, `post_category`
+- `platform`, `cta_id`, `form_id`, `placement`, `video_id`
+- `target_host`, `target_url`, `network`, `percent`
+- `metric_id`, `metric_value`, `metric_delta`, `metric_rating`, `debug_target`
+
+Then in GA4 admin → Events → mark these as **Key events** (conversions):
+
+- `cta_click` (filter to `cta_id` values you actually care about)
+- `form_submit`
+
+Web Vitals events surface automatically once received; no admin step.
+
+## Consent
+
+All custom events go through `trackEvent()` in `src/lib/gtag.ts`, which checks
+`window.hasAnalyticsConsent()` (exposed by `src/components/cookie-consent.tsx`)
+before forwarding to gtag. If the user hasn't accepted analytics cookies,
+all events silently no-op.
+
+## Adding new tracked events
+
+Use the wrappers in `src/components/analytics/track.tsx`:
+
+- `<TrackCtaButton ctaId="..." extra={{ ... }}>` — wraps a `<button>`.
+- `<TrackOutboundLink href="...">` — wraps an `<a>` to an external URL; fires `outbound_click` with `target_host` and `target_url`.
+- `<TrackVideoPlay videoId="..." placement="...">` — wraps content containing `<video>` elements; fires `video_play` once per video.
+- `<TrackScrollDepth contentRef={...}>` — null-rendering component; fires `scroll_depth` at 25/50/75/100% milestones.
+
+Or call `trackEvent(name, params)` directly from `@/lib/gtag` for ad-hoc events (e.g., from a form's `onSubmit` success branch).

--- a/docs/analytics-setup.md
+++ b/docs/analytics-setup.md
@@ -29,15 +29,15 @@ That's the only var required client-side. If unset, all tracking no-ops.
 
 ### `cta_id` reference
 
-| cta_id | Where | Notes |
-|---|---|---|
-| `download_header` | Top nav, desktop | |
-| `download_header_mobile` | Top nav, mobile | |
-| `download_option` | Download page extension/section cards | `platform` = the option's id (e.g. `chrome`, `firefox`, `mobile`). Note: `platform: 'mobile'` is a click on the "scroll to mobile section" card, not an actual install. |
-| `download_mobile` | Download page Play Store / App Store anchors | `platform: 'android' \| 'ios'`. These are real install-intent taps. |
-| `enterprise_launch_app` | Enterprise hero CTA | |
-| `enterprise_launch_app_contact` | Enterprise contact section | |
-| `enterprise_launch_app_footer` | Enterprise final CTA | |
+| cta_id                          | Where                                        | Notes                                                                                                                                                                   |
+| ------------------------------- | -------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `download_header`               | Top nav, desktop                             |                                                                                                                                                                         |
+| `download_header_mobile`        | Top nav, mobile                              |                                                                                                                                                                         |
+| `download_option`               | Download page extension/section cards        | `platform` = the option's id (e.g. `chrome`, `firefox`, `mobile`). Note: `platform: 'mobile'` is a click on the "scroll to mobile section" card, not an actual install. |
+| `download_mobile`               | Download page Play Store / App Store anchors | `platform: 'android' \| 'ios'`. These are real install-intent taps.                                                                                                     |
+| `enterprise_launch_app`         | Enterprise hero CTA                          |                                                                                                                                                                         |
+| `enterprise_launch_app_contact` | Enterprise contact section                   |                                                                                                                                                                         |
+| `enterprise_launch_app_footer`  | Enterprise final CTA                         |                                                                                                                                                                         |
 
 ## GA4 admin steps (one-time)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9724,6 +9724,17 @@
         }
       }
     },
+    "node_modules/next-intl/node_modules/@swc/helpers": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/next-themes": {
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,8 @@
         "rehype-pretty-code": "~0.14.3",
         "remark-gfm": "~4.0.1",
         "tailwind-merge": "~2.6.1",
-        "tailwindcss-animate": "~1.0.7"
+        "tailwindcss-animate": "~1.0.7",
+        "web-vitals": "^5.2.0"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "~4.1.18",
@@ -9723,17 +9724,6 @@
         }
       }
     },
-    "node_modules/next-intl/node_modules/@swc/helpers": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
-      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
-    },
     "node_modules/next-themes": {
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
@@ -12569,6 +12559,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.2.0.tgz",
+      "integrity": "sha512-i2z98bEmaCqSDiHEDu+gHl/dmR4Q+TxFmG3/13KkMO+o8UxQzCqWaDRCiLgEa41nlO4VpXSI0ASa1xWmO9sBlA==",
+      "license": "Apache-2.0"
     },
     "node_modules/whatwg-mimetype": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "rehype-pretty-code": "~0.14.3",
     "remark-gfm": "~4.0.1",
     "tailwind-merge": "~2.6.1",
-    "tailwindcss-animate": "~1.0.7"
+    "tailwindcss-animate": "~1.0.7",
+    "web-vitals": "^5.2.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "~4.1.18",

--- a/src/app/[locale]/academy/[category]/[slug]/page.tsx
+++ b/src/app/[locale]/academy/[category]/[slug]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import { notFound, permanentRedirect } from 'next/navigation'
 import Script from 'next/script'
 import { getTranslations, setRequestLocale } from 'next-intl/server'
+import { PageContext } from '@/components/analytics/page-context'
 import { LocalizedPathsRegistrar } from '@/components/i18n/localized-paths-registrar'
 import { AuthorByline } from '@/components/shared/author-byline'
 import { Breadcrumbs } from '@/components/shared/breadcrumbs'
@@ -134,6 +135,7 @@ export default async function AcademyArticlePage({ params }: PageProps) {
 
   return (
     <>
+      <PageContext section='academy' slug={slug} category={category} locale={locale} />
       <Script id='academy-article-jsonld' type='application/ld+json'>
         {JSON.stringify(articleJsonLd)}
       </Script>

--- a/src/app/[locale]/academy/[category]/page.tsx
+++ b/src/app/[locale]/academy/[category]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import Script from 'next/script'
 import { getTranslations, setRequestLocale } from 'next-intl/server'
+import { PageContext } from '@/components/analytics/page-context'
 import { PageHeader } from '@/components/header/page-header'
 import { NewsroomCard } from '@/components/newsroom/newsroom-card'
 import { Breadcrumbs } from '@/components/shared/breadcrumbs'
@@ -64,6 +65,7 @@ export default async function CategoryHubPage({
 
   return (
     <>
+      <PageContext section='academy_category' category={category} locale={locale} />
       <Script id='academy-category-breadcrumb-jsonld' type='application/ld+json'>
         {JSON.stringify(
           buildAcademyBreadcrumbJsonLd([

--- a/src/app/[locale]/contact/contact-content.tsx
+++ b/src/app/[locale]/contact/contact-content.tsx
@@ -18,6 +18,7 @@ import { useState } from 'react'
 import type { ComponentType, SVGProps } from 'react'
 import { useInView } from 'react-intersection-observer'
 import { Link } from '@/i18n/navigation'
+import { trackEvent } from '@/lib/gtag'
 
 interface ContactMethod {
   key: 'supportTickets' | 'discord' | 'github'
@@ -128,6 +129,7 @@ function ContactForm() {
       }
 
       setIsSubmitted(true)
+      trackEvent('form_submit', { form_id: 'contact' })
       setFormData({ name: '', email: '', company: '', subject: '', message: '', type: 'general' })
     } catch (err) {
       setError(err instanceof Error ? err.message : t('errorFallback'))

--- a/src/app/[locale]/download/download-content.tsx
+++ b/src/app/[locale]/download/download-content.tsx
@@ -7,6 +7,7 @@ import { useTranslations } from 'next-intl'
 import { useEffect, useState } from 'react'
 import { useInView } from 'react-intersection-observer'
 import { Link } from '@/i18n/navigation'
+import { trackEvent } from '@/lib/gtag'
 
 const CHROME_STORE_LINK =
   'https://chromewebstore.google.com/detail/ssp-wallet/mgfbabcnedcejkfibpafadgkhmkifhbd'
@@ -147,6 +148,12 @@ export function DownloadContent() {
                         href={extensionLink}
                         target='_blank'
                         rel='noopener noreferrer'
+                        onClick={() =>
+                          trackEvent('cta_click', {
+                            cta_id: 'download_option',
+                            platform: option.id,
+                          })
+                        }
                         className='bg-primary-600 hover:bg-primary-700 block w-full rounded-lg px-6 py-3 text-center font-medium text-white transition-colors'
                       >
                         {t(`options.${option.id}.cta`)}
@@ -154,6 +161,12 @@ export function DownloadContent() {
                     ) : (
                       <Link
                         href={option.link}
+                        onClick={() =>
+                          trackEvent('cta_click', {
+                            cta_id: 'download_option',
+                            platform: option.id,
+                          })
+                        }
                         className='bg-primary-600 hover:bg-primary-700 block w-full rounded-lg px-6 py-3 text-center font-medium text-white transition-colors'
                       >
                         {t(`options.${option.id}.cta`)}
@@ -270,6 +283,9 @@ export function DownloadContent() {
                   href='https://play.google.com/store/apps/details?id=io.runonflux.sspkey'
                   target='_blank'
                   rel='noopener noreferrer'
+                  onClick={() =>
+                    trackEvent('cta_click', { cta_id: 'download_mobile', platform: 'android' })
+                  }
                   className='dark:bg-dark-800 flex items-center justify-center rounded-lg border border-gray-200 bg-white p-4 transition-all hover:shadow-md dark:border-gray-700'
                 >
                   <div className='mr-3 h-8 w-8'>
@@ -293,6 +309,9 @@ export function DownloadContent() {
                   href='https://apps.apple.com/us/app/ssp-key/id6463717332'
                   target='_blank'
                   rel='noopener noreferrer'
+                  onClick={() =>
+                    trackEvent('cta_click', { cta_id: 'download_mobile', platform: 'ios' })
+                  }
                   className='dark:bg-dark-800 flex items-center justify-center rounded-lg border border-gray-200 bg-white p-4 transition-all hover:shadow-md dark:border-gray-700'
                 >
                   <div className='mr-3 h-8 w-8'>

--- a/src/app/[locale]/enterprise/enterprise-content.tsx
+++ b/src/app/[locale]/enterprise/enterprise-content.tsx
@@ -34,6 +34,7 @@ import { useTranslations } from 'next-intl'
 import { useState } from 'react'
 import { useInView } from 'react-intersection-observer'
 import { Link } from '@/i18n/navigation'
+import { trackEvent } from '@/lib/gtag'
 
 const DOCS_BASE = 'https://docs.sspwallet.io/enterprise'
 const POLICIES_DOCS = `${DOCS_BASE}/policies`
@@ -427,6 +428,7 @@ export function EnterpriseContent() {
                 href='https://enterprise.sspwallet.com'
                 target='_blank'
                 rel='noopener noreferrer'
+                onClick={() => trackEvent('cta_click', { cta_id: 'enterprise_launch_app' })}
                 className='btn btn-primary'
               >
                 {t('heroLaunchApp')}
@@ -1102,6 +1104,9 @@ export function EnterpriseContent() {
                   href='https://enterprise.sspwallet.com'
                   target='_blank'
                   rel='noopener noreferrer'
+                  onClick={() =>
+                    trackEvent('cta_click', { cta_id: 'enterprise_launch_app_contact' })
+                  }
                   className='btn btn-primary'
                 >
                   {t('contact.launchApp')}
@@ -1170,6 +1175,7 @@ export function EnterpriseContent() {
                 href='https://enterprise.sspwallet.com'
                 target='_blank'
                 rel='noopener noreferrer'
+                onClick={() => trackEvent('cta_click', { cta_id: 'enterprise_launch_app_footer' })}
                 className='btn btn-primary'
               >
                 {t('finalCta.launchApp')}

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -6,6 +6,7 @@ import Script from 'next/script'
 import { NextIntlClientProvider } from 'next-intl'
 import { getMessages, setRequestLocale } from 'next-intl/server'
 import type { ReactNode } from 'react'
+import { WebVitalsReporter } from '@/components/analytics/web-vitals-reporter'
 import CookieConsent from '@/components/cookie-consent'
 import { Footer } from '@/components/footer/footer'
 import { Header } from '@/components/header/header'
@@ -101,6 +102,7 @@ export default async function LocaleLayout({
               <main className='flex-1 overflow-x-hidden pt-16 md:pt-20'>{children}</main>
               <Footer />
             </div>
+            <WebVitalsReporter />
             <CookieConsent />
           </ThemeProvider>
         </NextIntlClientProvider>

--- a/src/app/[locale]/newsroom/[slug]/page.tsx
+++ b/src/app/[locale]/newsroom/[slug]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import { notFound, permanentRedirect } from 'next/navigation'
 import Script from 'next/script'
 import { setRequestLocale, getTranslations } from 'next-intl/server'
+import { PageContext } from '@/components/analytics/page-context'
 import { LocalizedPathsRegistrar } from '@/components/i18n/localized-paths-registrar'
 import { PostArticle } from '@/components/shared/post-article'
 import { routing, type Locale } from '@/i18n/routing'
@@ -107,6 +108,7 @@ export default async function NewsroomArticlePage({ params }: PageProps) {
 
   return (
     <>
+      <PageContext section='newsroom' slug={slug} locale={locale} />
       <Script id='blog-posting-jsonld' type='application/ld+json'>
         {JSON.stringify(blogPostingJsonLd)}
       </Script>

--- a/src/components/analytics/page-context.tsx
+++ b/src/components/analytics/page-context.tsx
@@ -3,9 +3,9 @@
 import { useEffect } from 'react'
 import { setContentContext, type ContentContext } from '@/lib/gtag'
 
-export function PageContext(props: ContentContext): null {
+export function PageContext({ section, slug, locale, category }: ContentContext): null {
   useEffect(() => {
-    setContentContext(props)
-  }, [props.section, props.slug, props.locale, props.category])
+    setContentContext({ section, slug, locale, category })
+  }, [section, slug, locale, category])
   return null
 }

--- a/src/components/analytics/page-context.tsx
+++ b/src/components/analytics/page-context.tsx
@@ -1,0 +1,11 @@
+'use client'
+
+import { useEffect } from 'react'
+import { setContentContext, type ContentContext } from '@/lib/gtag'
+
+export function PageContext(props: ContentContext): null {
+  useEffect(() => {
+    setContentContext(props)
+  }, [props.section, props.slug, props.locale, props.category])
+  return null
+}

--- a/src/components/analytics/track.tsx
+++ b/src/components/analytics/track.tsx
@@ -1,0 +1,108 @@
+'use client'
+
+import {
+  type AnchorHTMLAttributes,
+  type ButtonHTMLAttributes,
+  type ReactNode,
+  useEffect,
+  useRef,
+} from 'react'
+import { trackEvent } from '@/lib/gtag'
+
+export interface TrackCtaButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  ctaId: string
+  extra?: Record<string, string | number>
+  children: ReactNode
+}
+
+export function TrackCtaButton({ ctaId, extra, onClick, children, ...rest }: TrackCtaButtonProps) {
+  return (
+    <button
+      {...rest}
+      onClick={e => {
+        trackEvent('cta_click', { cta_id: ctaId, ...extra })
+        onClick?.(e)
+      }}
+    >
+      {children}
+    </button>
+  )
+}
+
+export interface TrackOutboundLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
+  href: string
+  children: ReactNode
+}
+
+export function TrackOutboundLink({ href, onClick, children, ...rest }: TrackOutboundLinkProps) {
+  return (
+    <a
+      {...rest}
+      href={href}
+      onClick={e => {
+        try {
+          const u = new URL(href)
+          trackEvent('outbound_click', { target_host: u.host, target_url: href })
+        } catch {
+          trackEvent('outbound_click', { target_host: '', target_url: href })
+        }
+        onClick?.(e)
+      }}
+    >
+      {children}
+    </a>
+  )
+}
+
+export interface TrackVideoPlayProps {
+  videoId: string
+  placement: string
+  children: ReactNode
+}
+
+export function TrackVideoPlay({ videoId, placement, children }: TrackVideoPlayProps) {
+  const ref = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    const root = ref.current
+    if (!root) return
+    const handler = (): void => {
+      trackEvent('video_play', { video_id: videoId, placement })
+    }
+    const videos = root.querySelectorAll('video')
+    videos.forEach(v => v.addEventListener('play', handler, { once: true }))
+    return () => videos.forEach(v => v.removeEventListener('play', handler))
+  }, [videoId, placement])
+  return <div ref={ref}>{children}</div>
+}
+
+export interface TrackScrollDepthProps {
+  contentRef: React.RefObject<HTMLElement | null>
+}
+
+const THRESHOLDS = [25, 50, 75, 100]
+
+export function TrackScrollDepth({ contentRef }: TrackScrollDepthProps) {
+  useEffect(() => {
+    const el = contentRef.current
+    if (!el) return
+    const fired = new Set<number>()
+    const onScroll = (): void => {
+      const rect = el.getBoundingClientRect()
+      const total = rect.height
+      const viewed = Math.min(window.innerHeight - rect.top, total)
+      const pct = Math.max(0, Math.min(100, (viewed / total) * 100))
+      for (const t of THRESHOLDS) {
+        if (pct >= t && !fired.has(t)) {
+          fired.add(t)
+          trackEvent('scroll_depth', { percent: t })
+        }
+      }
+    }
+    window.addEventListener('scroll', onScroll, { passive: true })
+    return () => window.removeEventListener('scroll', onScroll)
+  }, [contentRef])
+  return null
+}
+
+// Re-export trackEvent for ad-hoc use in instrumentation sites.
+export { trackEvent } from '@/lib/gtag'

--- a/src/components/analytics/web-vitals-reporter.tsx
+++ b/src/components/analytics/web-vitals-reporter.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+import { useEffect } from 'react'
+import {
+  onCLS,
+  onINP,
+  onLCP,
+  type CLSMetricWithAttribution,
+  type INPMetricWithAttribution,
+  type LCPMetricWithAttribution,
+} from 'web-vitals/attribution'
+import { trackEvent } from '@/lib/gtag'
+
+type WebVitalMetric = LCPMetricWithAttribution | INPMetricWithAttribution | CLSMetricWithAttribution
+
+function getDebugTarget(metric: WebVitalMetric): string {
+  const attr = metric.attribution as Record<string, unknown>
+  switch (metric.name) {
+    case 'LCP':
+      return (
+        (typeof attr['target'] === 'string' ? attr['target'] : (attr['element'] as string)) ?? ''
+      )
+    case 'INP':
+      return typeof attr['interactionTarget'] === 'string' ? attr['interactionTarget'] : ''
+    case 'CLS':
+      return typeof attr['largestShiftTarget'] === 'string' ? attr['largestShiftTarget'] : ''
+    default:
+      return ''
+  }
+}
+
+function sendToGa(metric: WebVitalMetric): void {
+  const isCLS = metric.name === 'CLS'
+  const value = Math.round(isCLS ? metric.delta * 1000 : metric.delta)
+  trackEvent(metric.name, {
+    value,
+    metric_id: metric.id,
+    metric_value: metric.value,
+    metric_delta: metric.delta,
+    metric_rating: metric.rating,
+    debug_target: getDebugTarget(metric),
+    non_interaction: true,
+  })
+}
+
+export function WebVitalsReporter(): null {
+  useEffect(() => {
+    onLCP(sendToGa)
+    onINP(sendToGa)
+    onCLS(sendToGa)
+  }, [])
+  return null
+}

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -10,6 +10,7 @@ import { LocaleSwitcher } from '@/components/header/locale-switcher'
 import { Logo } from '@/components/logo'
 import { useTheme } from '@/hooks/use-theme'
 import { Link, usePathname } from '@/i18n/navigation'
+import { trackEvent } from '@/lib/gtag'
 import { cn } from '@/lib/utils'
 
 type LinkItem = { kind: 'link'; name: string; href: string }
@@ -110,7 +111,11 @@ export function Header() {
                 )}
               </button>
             )}
-            <Link href='/download' className='btn btn-primary hidden md:inline-flex'>
+            <Link
+              href='/download'
+              className='btn btn-primary hidden md:inline-flex'
+              onClick={() => trackEvent('cta_click', { cta_id: 'download_header' })}
+            >
               <Download className='mr-2 h-4 w-4' />
               {t('download')}
             </Link>
@@ -179,7 +184,14 @@ export function Header() {
                   transition={{ delay: primaryNav.length * 0.03 }}
                   className='px-4 pt-2'
                 >
-                  <Link href='/download' onClick={closeMenu} className='btn btn-primary w-full'>
+                  <Link
+                    href='/download'
+                    onClick={() => {
+                      trackEvent('cta_click', { cta_id: 'download_header_mobile' })
+                      closeMenu()
+                    }}
+                    className='btn btn-primary w-full'
+                  >
                     <Download className='mr-2 h-4 w-4' />
                     {t('download')}
                   </Link>

--- a/src/lib/gtag.ts
+++ b/src/lib/gtag.ts
@@ -54,3 +54,38 @@ export const initGA = (): void => {
 export const isGALoaded = (): boolean => {
   return typeof window !== 'undefined' && typeof window.gtag === 'function'
 }
+
+function consentGranted(): boolean {
+  if (typeof window === 'undefined') return false
+  const fn = (window as unknown as { hasAnalyticsConsent?: () => boolean }).hasAnalyticsConsent
+  return typeof fn === 'function' ? fn() : false
+}
+
+export interface TrackEventParams {
+  [key: string]: string | number | boolean | undefined
+}
+
+export const trackEvent = (name: string, params: TrackEventParams = {}): void => {
+  if (typeof window === 'undefined' || typeof window.gtag !== 'function') return
+  if (!consentGranted()) return
+  window.gtag('event', name, params)
+}
+
+export interface ContentContext {
+  section: 'academy' | 'newsroom' | 'academy_category'
+  slug?: string
+  category?: string
+  locale: string
+}
+
+export const setContentContext = (ctx: ContentContext): void => {
+  if (typeof window === 'undefined' || typeof window.gtag !== 'function') return
+  if (!consentGranted()) return
+  window.gtag('set', {
+    content_group: ctx.section === 'academy_category' ? 'academy' : ctx.section,
+    post_section: ctx.section,
+    post_slug: ctx.slug ?? '',
+    post_locale: ctx.locale,
+    ...(ctx.category ? { post_category: ctx.category } : {}),
+  })
+}


### PR DESCRIPTION
## Summary

Adds analytics signal beyond bare pageviews on ssp-website. All new tracking is gated by the existing `window.hasAnalyticsConsent()` cookie-consent helper and no-ops when consent is absent.

### What's reported now

- **Core Web Vitals** (`LCP`, `INP`, `CLS`) — GA4 events with `metric_id`, `metric_value`, `metric_delta`, `metric_rating`, `debug_target` (DOM selector from `web-vitals/attribution`).
- **Content context** on academy/newsroom pages — `gtag('set', { content_group, post_section, post_slug, post_locale, post_category })` so reports can filter by section/language without URL scraping.
- **CTA conversions** — `cta_click` (with `cta_id` + optional `platform`) on header Download, download-page extension/mobile cards, Play/App Store anchors, Enterprise launch buttons; `form_submit` on contact form success.

### How it's built

- Extended `src/lib/gtag.ts` with `trackEvent(name, params)` and `setContentContext(ctx)`. Both check `window.gtag` + `window.hasAnalyticsConsent()` before forwarding.
- `src/components/analytics/web-vitals-reporter.tsx` — `'use client'` reporter mounted in `[locale]/layout.tsx`; subscribes to `onLCP`/`onINP`/`onCLS` from `web-vitals/attribution`.
- `src/components/analytics/page-context.tsx` — small null-rendering client component called from academy article, academy category, and newsroom slug pages.
- `src/components/analytics/track.tsx` — `TrackCtaButton`, `TrackOutboundLink`, `TrackVideoPlay`, `TrackScrollDepth` wrappers for future instrumentation. Existing CTAs use direct `onClick={() => trackEvent(...)}` for minimal markup churn.
- `docs/analytics-setup.md` — operator guide listing the custom GA4 dimensions to register and the `cta_id` taxonomy.

### New dependency

- `web-vitals@^5.2.0` (runtime).

## Test plan

- [x] Unit tests for `trackEvent` / `setContentContext` (no-op without gtag, no-op without consent, call-through with consent, payload shape)
- [x] Unit tests for `WebVitalsReporter` (registers all three observers, forwards metric to gtag)
- [x] Unit tests for `PageContext` (calls setContentContext, renders null)
- [x] Unit tests for `TrackCtaButton`, `TrackOutboundLink`, `TrackVideoPlay`
- [x] `tsc --noEmit`, `npm run lint`, full vitest run all green
- [x] Production `npm run build` succeeds
- [ ] Manual UAT: accept analytics consent, open `/en/academy/<slug>` and verify a `page_view` arrives in GA4 DebugView with `content_group=academy`, `post_slug=<slug>`, `post_locale=en`.
- [ ] Manual UAT: tap the header Download button and verify a `cta_click` event arrives with `cta_id=download_header`.
- [ ] Manual UAT: confirm `LCP`/`INP`/`CLS` events appear in GA4 DebugView within ~20 seconds of pageload (INP may need a real interaction).

## GA4 admin follow-ups

Before reports show the new dimensions, register them in GA4 admin (see `docs/analytics-setup.md` for the full list). Mark `cta_click` and `form_submit` as Key events.